### PR TITLE
chore: sync upstream opensearch snap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,83 +122,12 @@ jobs:
               exit 1
           fi
 
-      - name: Check if Prometheus Exporter and repository plugins are available
-        env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
-          OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
-          OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
-          OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
-          OPENSEARCH_LIB: /var/snap/opensearch/current/usr/share/opensearch/lib
-          OPENSEARCH_PATH_CERTS: /var/snap/opensearch/current/etc/opensearch/certificates
-        run: |
-          # Prometheus Exporter appears in plugins listing
-          prometheus_is_there=$(sudo opensearch.plugin list | grep prometheus-exporter)
-          if [ ! "$prometheus_is_there" ]; then
-            exit 1
-          fi
-          # repository-s3 appears in plugins listing
-          repository_s3_is_there=$(sudo opensearch.plugin list | grep repository-s3)
-          if [ ! "$repository_s3_is_there" ]; then
-            exit 1
-          fi
-          # repository-gcs appears in plugins listing
-          repository_gcs_is_there=$(sudo opensearch.plugin list | grep repository-gcs)
-          if [ ! "$repository_gcs_is_there" ]; then
-            exit 1
-          fi
-          # repository-azure appears in plugins listing
-          repository_azure_is_there=$(sudo opensearch.plugin list | grep repository-azure)
-          if [ ! "$repository_azure_is_there" ]; then
-            exit 1
-          fi
-
-          # Prometheus exporter can be queried
-          sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
-          cert=./node-cm0.pem
-          resp=$(curl -I --cacert ${cert} -XGET https://localhost:9200/_prometheus/metrics -u 'admin:admin')
-          if [[ "$resp" != *"200 OK"* ]]; then
-            exit 1
-          fi
-
-          # Checking that Prometheus configuration is correct
-          prometheus_lines=$(sudo grep prometheus ${OPENSEARCH_PATH_CONF}/opensearch.yml | wc -l)
-          if [ "$prometheus_lines" != "4" ]; then
-            exit 1
-          fi
-
       - name: Check COS logs slot is available
         run: |
           snap_slot=$( sudo snap connections opensearch | grep content )
           if [ ! "$snap_slot" ]; then
             exit 1
           fi 
-
-      - name: Configure backup plugin 
-        env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
-          OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
-          OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
-          OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
-          OPENSEARCH_LIB: /var/snap/opensearch/current/usr/share/opensearch/lib
-          OPENSEARCH_PATH_CERTS: /var/snap/opensearch/current/etc/opensearch/certificates
-        run: |
-          echo "TEST" | sudo tee -a ${OPENSEARCH_PATH_CONF}/testkey
-
-          sudo opensearch.keystore add-file s3.client.default.access_key ${OPENSEARCH_PATH_CONF}/testkey
-          sudo opensearch.keystore add-file s3.client.default.secret_key ${OPENSEARCH_PATH_CONF}/testkey
-
-          sudo snap restart opensearch.daemon
-          sleep 20s
-
-          sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
-          cert=./node-cm0.pem
-
-          cluster_resp=$(curl --cacert ${cert} -XGET https://localhost:9200 -u 'admin:admin')
-          echo -e "Cluster Response: \n ${cluster_resp}"
-          node_name=$(echo "${cluster_resp}" | yq -r .name)
-          if [ "${node_name}" != "cm0" ]; then
-              exit 1
-          fi
 
       - name: Upgrade snap
         run: |
@@ -238,16 +167,3 @@ jobs:
               curl --cacert ${cert} -XGET https://localhost:9200/_cat/shards -u 'admin:admin'
               exit 1
           fi
-
-      - name: Remove backup plugin
-        env:
-          OPENSEARCH_JAVA_HOME: /snap/opensearch/current/usr/lib/jvm/java-21-openjdk-amd64
-          OPENSEARCH_BIN: /snap/opensearch/current/usr/share/opensearch/bin
-          OPENSEARCH_PATH_CONF: /var/snap/opensearch/current/etc/opensearch
-          OPENSEARCH_HOME: /var/snap/opensearch/current/usr/share/opensearch
-          OPENSEARCH_LIB: /var/snap/opensearch/current/usr/share/opensearch/lib
-          OPENSEARCH_PATH_CERTS: /var/snap/opensearch/current/etc/opensearch/certificates
-        run: |
-          sudo opensearch.plugin remove repository-s3
-          sudo opensearch.keystore remove s3.client.default.access_key
-          sudo opensearch.keystore remove s3.client.default.secret_key

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Upload built snap job artifact
         uses: actions/upload-artifact@v4
         with:
-          name: opensearch_snap_amd64
-          path: "opensearch_*.snap"
+          name: charmed-opensearch_snap_amd64
+          path: "charmed-opensearch_*.snap"
 
   test:
     name: Test Snap
@@ -50,15 +50,15 @@ jobs:
       - name: Download snap file
         uses: actions/download-artifact@v4
         with:
-          name: opensearch_snap_amd64
+          name: charmed-opensearch_snap_amd64
           path: .
 
       - name: Install snap file
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
           
-          sudo snap remove --purge opensearch
-          sudo snap install opensearch_${version}_amd64.snap --dangerous --jailmode
+          sudo snap remove --purge charmed-opensearch
+          sudo snap install charmed-opensearch_${version}_amd64.snap --dangerous --jailmode
 
       - name: Setup the required system configs
         run: |
@@ -68,17 +68,17 @@ jobs:
 
       - name: Connect required interfaces
         run: |
-          sudo snap connect opensearch:log-observe
-          sudo snap connect opensearch:mount-observe
-          sudo snap connect opensearch:process-control
-          sudo snap connect opensearch:system-observe
-          sudo snap connect opensearch:sys-fs-cgroup-service
-          sudo snap connect opensearch:shmem-perf-analyzer
+          sudo snap connect charmed-opensearch:log-observe
+          sudo snap connect charmed-opensearch:mount-observe
+          sudo snap connect charmed-opensearch:process-control
+          sudo snap connect charmed-opensearch:system-observe
+          sudo snap connect charmed-opensearch:sys-fs-cgroup-service
+          sudo snap connect charmed-opensearch:shmem-perf-analyzer
 
       - name: Setup and Start OpenSearch
         run: |
           # create the certificates
-          sudo snap run opensearch.setup \
+          sudo snap run charmed-opensearch.setup \
               --node-name cm0 \
               --node-roles cluster_manager,data \
               --tls-priv-key-root-pass root1234 \
@@ -87,19 +87,19 @@ jobs:
               --tls-init-setup yes                 # this creates the root and admin certs as well.
 
           # start opensearch
-          sudo snap start opensearch.daemon
+          sudo snap start charmed-opensearch.daemon
 
           # wait a bit for it to fully initialize
           sleep 40s
           # create the security index
-          sudo snap run opensearch.security-init --tls-priv-key-admin-pass=admin1234
+          sudo snap run charmed-opensearch.security-init --tls-priv-key-admin-pass=admin1234
           sleep 15s
 
       - name: Ensure the cluster is reachable and node created
         run: |
           sudo snap install yq
           
-          sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
+          sudo cp /var/snap/charmed-opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
           cert=./node-cm0.pem
           
           # Check node name
@@ -124,7 +124,7 @@ jobs:
 
       - name: Check COS logs slot is available
         run: |
-          snap_slot=$( sudo snap connections opensearch | grep content )
+          snap_slot=$( sudo snap connections charmed-opensearch | grep content )
           if [ ! "$snap_slot" ]; then
             exit 1
           fi 
@@ -132,9 +132,9 @@ jobs:
       - name: Upgrade snap
         run: |
           version="$(cat snap/snapcraft.yaml | yq .version)"
-          sudo snap install opensearch_${version}_amd64.snap --dangerous --jailmode
+          sudo snap install charmed-opensearch_${version}_amd64.snap --dangerous --jailmode
 
-          if [ "$(ls /var/snap/opensearch/x2)" ]; then
+          if [ "$(ls /var/snap/charmed-opensearch/x2)" ]; then
               echo "Snap upgraded."
           else
               exit 1
@@ -143,11 +143,11 @@ jobs:
       - name: Ensure the cluster is reachable and node created after upgrade
         run: |
           # start opensearch after upgrade
-          sudo snap restart opensearch.daemon
+          sudo snap restart charmed-opensearch.daemon
           # Give some time for the service to come back up
           sleep 20s
 
-          sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
+          sudo cp /var/snap/charmed-opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
           cert=./node-cm0.pem
 
           # Check node name

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Download snap file
         uses: actions/download-artifact@v4
         with:
-          name: opensearch_snap_amd64
+          name: charmed-opensearch_snap_amd64
           path: .
 
       - name: Set snap release channel
@@ -48,7 +48,7 @@ jobs:
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
         with:
-          snap: opensearch_${{env.version}}_amd64.snap
+          snap: charmed-opensearch_${{env.version}}_amd64.snap
           release: ${{env.channel}}
 
       - name: Upload snapcraft logs

--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ curl --cacert node-cm0.pem -XGET https://admin:admin@localhost:9200/_cluster/hea
 ## License
 The Charmed Opensearch Snap is free software, distributed under the Apache
 Software License, version 2.0. See
-[LICENSE](https://github.com/canonical/charmed-opensearch-snap/blob/main/licenses/LICENSE-snap)
+[LICENSE](https://github.com/canonical/charmed-opensearch-snap/blob/2/edge/licenses/LICENSE-snap)
 for more information.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OpenSearch-Snap
-[![Build and Test](https://github.com/canonical/opensearch-snap/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/opensearch-snap/actions/workflows/ci.yaml)
-[![Publish](https://github.com/canonical/opensearch-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/opensearch-snap/actions/workflows/release.yaml)
+# Charmed OpenSearch Snap
+[![Build and Test](https://github.com/canonical/charmed-opensearch-snap/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/charmed-opensearch-snap/actions/workflows/ci.yaml)
+[![Publish](https://github.com/canonical/charmed-opensearch-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/charmed-opensearch-snap/actions/workflows/release.yaml)
 
 [//]: # (<h1 align="center">)
 [//]: # (  <a href="https://opensearch.org/">)
@@ -14,12 +14,12 @@ analytics suite that makes it easy to ingest, search, visualize, and analyze dat
 
 
 ### Installation:
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/opensearch)
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/charmed-opensearch)
 
 or:
 ```
-sudo snap install opensearch --channel=2/edge
-sudo snap connect opensearch:process-control
+sudo snap install charmed-opensearch --channel=2/edge
+sudo snap connect charmed-opensearch:process-control
 ```
 
 ### Environment configuration:
@@ -30,11 +30,11 @@ sudo sysctl -w vm.max_map_count=262144
 sudo sysctl -w net.ipv4.tcp_retries2=5
 ```
 
-### Starting OpenSearch:
+### Starting Charmed OpenSearch:
 #### Creating certificates:
 ```
 # create the certificates
-sudo snap run opensearch.setup          \
+sudo snap run charmed-opensearch.setup          \
     --node-name cm0                     \
     --node-roles cluster_manager,data   \
     --tls-priv-key-root-pass root1234   \
@@ -43,40 +43,40 @@ sudo snap run opensearch.setup          \
     --tls-init-setup yes    # this creates the root and admin certs as well.
 ```
 
-#### Starting OpenSearch:
+#### Starting Charmed OpenSearch:
 ```
-sudo snap start opensearch.daemon
+sudo snap start charmed-opensearch.daemon
 ```
 
 #### Creating the Security Index:
 ```
-sudo snap run opensearch.security-init --tls-priv-key-admin-pass=admin1234
+sudo snap run charmed-opensearch.security-init --tls-priv-key-admin-pass=admin1234
 ```
 
-### Testing the OpenSearch setup:
+### Testing the Charmed OpenSearch setup:
 You can either consume the REST API yourself or see if the below commands succeed, and you see that the tests `"PASSED"` successfully: 
 ```
 # Check if cluster is healthy (green):
-sudo snap run opensearch.test-cluster-health-green
+sudo snap run charmed-opensearch.test-cluster-health-green
 > ....
 > PASSED
 
 
 # Check if node is up:
-sudo snap run opensearch.test-node-up
+sudo snap run charmed-opensearch.test-node-up
 > ....
 > PASSED
 
 
 # Check if the security index is well initialised:
-sudo snap run opensearch.test-security-index-created
+sudo snap run charmed-opensearch.test-security-index-created
 > ....
 > PASSED
 ```
 
 or:
 ```
-sudo cp /var/snap/opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
+sudo cp /var/snap/charmed-opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
 curl --cacert node-cm0.pem -XGET https://admin:admin@localhost:9200/_cluster/health?pretty
 > {
   "cluster_name": "opensearch-cluster",
@@ -100,7 +100,7 @@ curl --cacert node-cm0.pem -XGET https://admin:admin@localhost:9200/_cluster/hea
 ```
 
 ## License
-The Opensearch Snap is free software, distributed under the Apache
+The Charmed Opensearch Snap is free software, distributed under the Apache
 Software License, version 2.0. See
-[LICENSE](https://github.com/canonical/opensearch-snap/blob/main/licenses/LICENSE-snap)
+[LICENSE](https://github.com/canonical/charmed-opensearch-snap/blob/main/licenses/LICENSE-snap)
 for more information.

--- a/scripts/wrappers/keystore-wrapper.sh
+++ b/scripts/wrappers/keystore-wrapper.sh
@@ -2,4 +2,4 @@
 
 set -e -o pipefail
 
-snap run --shell opensearch.daemon -- /snap/opensearch/current/usr/share/opensearch/bin/opensearch-keystore.orig "${@}"
+snap run --shell charmed-opensearch.daemon -- /snap/charmed-opensearch/current/usr/share/opensearch/bin/opensearch-keystore.orig "${@}"

--- a/scripts/wrappers/plugin-wrapper.sh
+++ b/scripts/wrappers/plugin-wrapper.sh
@@ -2,4 +2,4 @@
 
 set -e -o pipefail
 
-snap run --shell opensearch.daemon -- /snap/opensearch/current/usr/share/opensearch/bin/opensearch-plugin.orig "${@}"
+snap run --shell charmed-opensearch.daemon -- /snap/charmed-opensearch/current/usr/share/opensearch/bin/opensearch-plugin.orig "${@}"

--- a/setup-dev-env.sh
+++ b/setup-dev-env.sh
@@ -2,12 +2,12 @@
 
 
 function connect_interfaces () {
-    sudo snap connect opensearch:log-observe
-    sudo snap connect opensearch:mount-observe
-    sudo snap connect opensearch:process-control
-    sudo snap connect opensearch:system-observe
-    sudo snap connect opensearch:sys-fs-cgroup-service
-    sudo snap connect opensearch:shmem-perf-analyzer
+    sudo snap connect charmed-opensearch:log-observe
+    sudo snap connect charmed-opensearch:mount-observe
+    sudo snap connect charmed-opensearch:process-control
+    sudo snap connect charmed-opensearch:system-observe
+    sudo snap connect charmed-opensearch:sys-fs-cgroup-service
+    sudo snap connect charmed-opensearch:shmem-perf-analyzer
 }
 
 

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -45,17 +45,8 @@ function set_base_config_props () {
 }
 
 
-function set_prometheus_exporter_config_props() {
-    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.metric_name.prefix" "opensearch_"
-    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.indices" "false"
-    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.cluster.settings" "false"
-    set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "prometheus.nodes.filter" "_local"
-}
-
-
 create_file_structure
 set_base_config_props
-set_prometheus_exporter_config_props
 
 #  "${SNAP_COMMON}"
 declare -a folders=("${SNAP_DATA}")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -295,6 +295,15 @@ parts:
       curl -L -o "${archive}" "${url}"
       tar -xzvf "${archive}" -C "${CRAFT_PART_INSTALL}/" --strip-components=1
 
+      # remove non-core plugins
+      JAVA_PATH="$(dirname $(readlink -f $(which java)))"
+      export JAVA_HOME="${JAVA_PATH%/*}"
+      
+      remove_plugins=(prometheus-exporter repository-azure repository-gcs repository-s3)
+      for plugin in "${remove_plugins[@]}"; do
+        "${CRAFT_PART_INSTALL}"/bin/opensearch-plugin remove "${plugin}"
+      done
+
       mkdir -p "${CRAFT_PART_INSTALL}/usr/share/opensearch"
 
       mkdir -p "${CRAFT_PART_INSTALL}/etc/opensearch/"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,4 +1,4 @@
-name: opensearch # you probably want to 'snapcraft register <name>'
+name: charmed-opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
 version: '2.19.2' # just for humans, typically '1.2+git' or '1.3.2'
@@ -55,8 +55,8 @@ hooks:
 
 
 environment:
-  SNAP_CURRENT: /snap/opensearch/current
-  SNAP_DATA_CURRENT: /var/snap/opensearch/current
+  SNAP_CURRENT: /snap/charmed-opensearch/current
+  SNAP_DATA_CURRENT: /var/snap/charmed-opensearch/current
   JAVA_HOME: ${SNAP}/usr/lib/jvm/java-21-openjdk-amd64
   PATH: ${JAVA_HOME}/jre/bin:$PATH
   HOME: ${SNAP_COMMON}/home/snap_daemon

--- a/test-dev-cluster.sh
+++ b/test-dev-cluster.sh
@@ -48,19 +48,19 @@ function parse_args () {
 function run_tests () {
     # Check if cluster is healthy (green):
     echo "Running: test-cluster-health-green..."
-    sudo snap run opensearch.test-cluster-health-green --admin-auth-password "${admin_auth_password}"
+    sudo snap run charmed-opensearch.test-cluster-health-green --admin-auth-password "${admin_auth_password}"
 
     echo -e "\n\n---------------\n\n"
 
     # Check if node is up:
     echo "Running: test-node-up..."
-    sudo snap run opensearch.test-node-up --admin-auth-password "${admin_auth_password}"
+    sudo snap run charmed-opensearch.test-node-up --admin-auth-password "${admin_auth_password}"
 
     echo -e "\n\n---------------\n\n"
 
     # Check if the security index is well initialised:
     echo "Running: test-security-index-created..."
-    sudo snap run opensearch.test-security-index-created --admin-auth-password "${admin_auth_password}"
+    sudo snap run charmed-opensearch.test-security-index-created --admin-auth-password "${admin_auth_password}"
 }
 
 


### PR DESCRIPTION
This PR:
- Syncs with upstream opensearch snap
-  Changes the name to charmed-opensearch-snap