### PR TITLE
chore: sync upstream

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,8 +155,8 @@ jobs:
           # Prometheus exporter can be queried
           sudo cp /var/snap/charmed-opensearch/current/etc/opensearch/certificates/node-cm0.pem ./
           cert=./node-cm0.pem
-          resp=$(curl -I --cacert ${cert} -XGET https://localhost:9200/_prometheus/metrics -u 'admin:admin')
-          if [[ "$resp" != *"200 OK"* ]]; then
+          resp=$(curl -s -o /dev/null -w "%{http_code}" --cacert ${cert} -XGET https://localhost:9200/_prometheus/metrics -u 'admin:admin')
+          if [[ "$resp" != "200" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ env:
 on:
   push:
     branches:
-      - '2/edge'
+      - '3/edge'
   workflow_call:
 
 jobs:

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -41,6 +41,7 @@ function set_base_config_props () {
     set_yaml_prop "${OPENSEARCH_PATH_CONF}/opensearch.yml" "path.home" "${OPENSEARCH_HOME}"
 
     replace_in_file "${OPENSEARCH_PATH_CONF}/jvm.options" "=logs/" "=${OPENSEARCH_VARLOG}/"
+    replace_in_file "${OPENSEARCH_PATH_CONF}/jvm.options" "-javaagent:" "-javaagent:${SNAP_CURRENT}/"
     echo "-Duser.home=${HOME}" | tee -a "${OPENSEARCH_PATH_CONF}/jvm.options"
 }
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-opensearch # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
 
-version: '2.19.2' # just for humans, typically '1.2+git' or '1.3.2'
+version: '3.1.0' # just for humans, typically '1.2+git' or '1.3.2'
 
 summary: 'OpenSearch: community-driven, Apache 2.0-licensed search and analytics suite.'
 description: |
@@ -288,7 +288,7 @@ parts:
       version="$(craftctl get version)"
       series="${version%%.*}.x"
       patch="ubuntu0"
-      release_date="20250623142957"
+      release_date="20250730162625"
 
       archive="opensearch-${version}-${patch}-${release_date}-linux-x64.tar.gz"
       url="https://launchpad.net/opensearch-releases/${series}/${version}-${patch}/+download/${archive}"


### PR DESCRIPTION
This PR:
- syncs changes from the upstream`3/edge` branch
- Updates the Prometheus exporter test to expect a HTTP/2 response

Addresses [DPE-7809]

[DPE-7809]: https://warthogs.atlassian.net/browse/DPE-7809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ